### PR TITLE
FDP-598 Liberar acesso ao recurso de sistema [campo_sistema] para usuário não administrador

### DIFF
--- a/app/functions/autenticar_usuario.php
+++ b/app/functions/autenticar_usuario.php
@@ -176,6 +176,8 @@
     if (
         !($vb_usuario_administrador && $vb_usuario_logado_instituicao_admin)
         &&
+        (!in_array($vs_id_objeto_tela, ["campo_sistema"]))
+        &&
         (in_array($vs_id_objeto_tela, ["grupo_usuario"]) || in_array($vs_id_objeto_tela, config::get(["sidebar"])["configuracoes"]))
     )
     {


### PR DESCRIPTION
Para adição de campos em visualizações. O acesso definitivo é liberado nas permissões do grupo de usuários. O acesso via menu continua bloqueado.